### PR TITLE
Add Android.mk for building hdcp service on Android

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,2 @@
+# Recursively call sub-folder Android.mk
+include $(call all-subdir-makefiles)

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -1,23 +1,24 @@
-#----------------------------------------------------------------------------
-# INTEL CONFIDENTIAL
-# Copyright (2002-2017) Intel Corporation All Rights Reserved.
-# The source code contained or described herein and all documents related to
-# the source code ("Material") are owned by Intel Corporation or its suppliers
-# or licensors. Title to the Material remains with Intel Corporation or its
-# suppliers and licensors. The Material contains trade secrets and proprietary
-# and confidential information of Intel or its suppliers and licensors. The
-# Material is protected by worldwide copyright and trade secret laws and
-# treaty provisions. No part of the Material may be used, copied, reproduced,
-# modified, published, uploaded, posted, transmitted, distributed, or
-# disclosed in any way without Intel's prior express written permission.
-#
-# No license under any patent, copyright, trade secret or other intellectual
-# property right is granted to or conferred upon you by disclosure or
-# delivery of the Materials, either expressly, by implication, inducement,
-# estoppel or otherwise. Any license under such intellectual property rights
-# must be express and approved by Intel in writing.
-#
-#----------------------------------------------------------------------------
+/*
+* Copyright (c) 2009-2018, Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+* OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*/
 
 LOCAL_PATH := $(call my-dir)
 

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -1,0 +1,60 @@
+#----------------------------------------------------------------------------
+# INTEL CONFIDENTIAL
+# Copyright (2002-2017) Intel Corporation All Rights Reserved.
+# The source code contained or described herein and all documents related to
+# the source code ("Material") are owned by Intel Corporation or its suppliers
+# or licensors. Title to the Material remains with Intel Corporation or its
+# suppliers and licensors. The Material contains trade secrets and proprietary
+# and confidential information of Intel or its suppliers and licensors. The
+# Material is protected by worldwide copyright and trade secret laws and
+# treaty provisions. No part of the Material may be used, copied, reproduced,
+# modified, published, uploaded, posted, transmitted, distributed, or
+# disclosed in any way without Intel's prior express written permission.
+#
+# No license under any patent, copyright, trade secret or other intellectual
+# property right is granted to or conferred upon you by disclosure or
+# delivery of the Materials, either expressly, by implication, inducement,
+# estoppel or otherwise. Any license under such intellectual property rights
+# must be express and approved by Intel in writing.
+#
+#----------------------------------------------------------------------------
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_CPPFLAGS := \
+    -DANDROID \
+    -DANDROID_VERSION=800 \
+    -DHDCP_LOG_TAG="\"HDCPD\"" \
+
+ifeq ($(ENABLE_DEBUG),1)
+    LOCAL_CPPFLAG += \
+        -DLOG_CONSOLE \
+        -DHDCP_USE_VERBOSE_LOGGING \
+        -DHDCP_USE_FUNCTION_LOGGING \
+        -DHDCP_USE_LINK_FUNCTION_LOGGING
+endif
+
+#WA
+LOCAL_CPPFLAGS += \
+    -Wno-error
+
+LOCAL_C_INCLUDES += \
+    $(LOCAL_PATH)/../sdk \
+    $(LOCAL_PATH)/../common \
+
+LOCAL_SHARED_LIBRARIES := \
+    libutils \
+    liblog \
+
+LOCAL_SRC_FILES := \
+    clientsock.cpp \
+    gensock.cpp \
+    servsock.cpp \
+    socketdata.cpp \
+
+LOCAL_MODULE := libhdcpcommon
+LOCAL_PROPRIETARY_MODULE := true
+
+include $(BUILD_STATIC_LIBRARY)

--- a/common/socketdata.h
+++ b/common/socketdata.h
@@ -34,8 +34,13 @@
 #define MAX_LISTENER_SOCKET_PATH    64
 
 // socket file used by SDK and daemon
+#ifdef ANDROID
+#define HDCP_DIR_BASE               "/data/hdcp/"
+#define HDCP_DIR_BASE_PERMISSIONS   (S_IRWXU | S_IRWXG)
+#else
 #define HDCP_DIR_BASE               "/var/run/hdcp/"
 #define HDCP_DIR_BASE_PERMISSIONS   (S_IRWXU | S_IRWXG | S_IRWXO)
+#endif
 #define HDCP_SDK_SOCKET_PATH        HDCP_DIR_BASE ".sdk_socket"
 
 typedef enum _HDCP_API_TYPE

--- a/daemon/Android.mk
+++ b/daemon/Android.mk
@@ -1,23 +1,24 @@
-#----------------------------------------------------------------------------
-# INTEL CONFIDENTIAL
-# Copyright (2002-2017) Intel Corporation All Rights Reserved.
-# The source code contained or described herein and all documents related to
-# the source code ("Material") are owned by Intel Corporation or its suppliers
-# or licensors. Title to the Material remains with Intel Corporation or its
-# suppliers and licensors. The Material contains trade secrets and proprietary
-# and confidential information of Intel or its suppliers and licensors. The
-# Material is protected by worldwide copyright and trade secret laws and
-# treaty provisions. No part of the Material may be used, copied, reproduced,
-# modified, published, uploaded, posted, transmitted, distributed, or
-# disclosed in any way without Intel's prior express written permission.
-#
-# No license under any patent, copyright, trade secret or other intellectual
-# property right is granted to or conferred upon you by disclosure or
-# delivery of the Materials, either expressly, by implication, inducement,
-# estoppel or otherwise. Any license under such intellectual property rights
-# must be express and approved by Intel in writing.
-#
-#----------------------------------------------------------------------------
+/*
+* Copyright (c) 2009-2018, Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+* OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*/
 
 LOCAL_PATH := $(call my-dir)
 

--- a/daemon/Android.mk
+++ b/daemon/Android.mk
@@ -1,0 +1,70 @@
+#----------------------------------------------------------------------------
+# INTEL CONFIDENTIAL
+# Copyright (2002-2017) Intel Corporation All Rights Reserved.
+# The source code contained or described herein and all documents related to
+# the source code ("Material") are owned by Intel Corporation or its suppliers
+# or licensors. Title to the Material remains with Intel Corporation or its
+# suppliers and licensors. The Material contains trade secrets and proprietary
+# and confidential information of Intel or its suppliers and licensors. The
+# Material is protected by worldwide copyright and trade secret laws and
+# treaty provisions. No part of the Material may be used, copied, reproduced,
+# modified, published, uploaded, posted, transmitted, distributed, or
+# disclosed in any way without Intel's prior express written permission.
+#
+# No license under any patent, copyright, trade secret or other intellectual
+# property right is granted to or conferred upon you by disclosure or
+# delivery of the Materials, either expressly, by implication, inducement,
+# estoppel or otherwise. Any license under such intellectual property rights
+# must be express and approved by Intel in writing.
+#
+#----------------------------------------------------------------------------
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_CPPFLAGS :=                                           \
+    -DANDROID \
+    -DANDROID_VERSION=800 \
+    -DHDCP_LOG_TAG="\"HDCPD\""
+
+ifeq ($(ENABLE_DEBUG),1)
+    LOCAL_CPPFLAG += \
+        -DLOG_CONSOLE \
+        -DHDCP_USE_VERBOSE_LOGGING \
+        -DHDCP_USE_FUNCTION_LOGGING \
+        -DHDCP_USE_LINK_FUNCTION_LOGGING
+endif
+
+#WA
+LOCAL_CPPFLAGS += \
+    -Wno-error
+
+LOCAL_SHARED_LIBRARIES := \
+    libutils \
+    libbinder \
+    liblog \
+    libcrypto \
+    libdrm \
+    libssl \
+    libhwcservice
+
+LOCAL_STATIC_LIBRARIES := \
+    libhdcpcommon \
+
+LOCAL_SRC_FILES := \
+    main.cpp \
+    daemon.cpp \
+    port.cpp \
+    srm.cpp \
+    portmanager.cpp \
+
+LOCAL_C_INCLUDES := \
+    $(LOCAL_PATH) \
+    $(LOCAL_PATH)/../sdk \
+    $(LOCAL_PATH)/../common
+
+LOCAL_MODULE := hdcpd
+LOCAL_PROPRIETARY_MODULE := true
+
+include $(BUILD_EXECUTABLE)

--- a/daemon/Android.mk
+++ b/daemon/Android.mk
@@ -24,7 +24,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_CPPFLAGS :=                                           \
+LOCAL_CPPFLAGS := \
     -DANDROID \
     -DANDROID_VERSION=800 \
     -DHDCP_LOG_TAG="\"HDCPD\""

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -38,6 +38,12 @@
 
 #define APP_ID_INTERNAL     0
 
+#ifdef ANDROID
+#define HDCP_PIDFILE    "/data/hdcp/hdcpd.pid"
+#else
+#define HDCP_PIDFILE    "/var/run/hdcpd.pid"
+#endif
+
 class HdcpDaemon
 {
 private:

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -47,7 +47,11 @@ FILE *dmLog = nullptr;
 
 bool AlreadyRunning()
 {
+#ifdef ANDROID
+    const std::string pidFile = "/data/hdcp/hdcpd.pid";
+#else
     const std::string pidFile = "/var/run/hdcpd.pid";
+#endif
 
     int fd = open(pidFile.c_str(),
                 O_RDWR | O_CREAT,

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -47,12 +47,8 @@ FILE *dmLog = nullptr;
 
 bool AlreadyRunning()
 {
-#ifdef ANDROID
-    const std::string pidFile = "/data/hdcp/hdcpd.pid";
-#else
-    const std::string pidFile = "/var/run/hdcpd.pid";
-#endif
-
+    const std::string pidFile = HDCP_PIDFILE;
+    
     int fd = open(pidFile.c_str(),
                 O_RDWR | O_CREAT,
                 S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);

--- a/sdk/Android.mk
+++ b/sdk/Android.mk
@@ -1,23 +1,24 @@
-#----------------------------------------------------------------------------
-# INTEL CONFIDENTIAL
-# Copyright (2002-2014) Intel Corporation All Rights Reserved.
-# The source code contained or described herein and all documents related to
-# the source code ("Material") are owned by Intel Corporation or its suppliers
-# or licensors. Title to the Material remains with Intel Corporation or its
-# suppliers and licensors. The Material contains trade secrets and proprietary
-# and confidential information of Intel or its suppliers and licensors. The
-# Material is protected by worldwide copyright and trade secret laws and
-# treaty provisions. No part of the Material may be used, copied, reproduced,
-# modified, published, uploaded, posted, transmitted, distributed, or
-# disclosed in any way without Intel's prior express written permission.
-#
-# No license under any patent, copyright, trade secret or other intellectual
-# property right is granted to or conferred upon you by disclosure or
-# delivery of the Materials, either expressly, by implication, inducement,
-# estoppel or otherwise. Any license under such intellectual property rights
-# must be express and approved by Intel in writing.
-#
-#----------------------------------------------------------------------------
+/*
+* Copyright (c) 2009-2018, Intel Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+* OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*/
 
 LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)

--- a/sdk/Android.mk
+++ b/sdk/Android.mk
@@ -1,0 +1,65 @@
+#----------------------------------------------------------------------------
+# INTEL CONFIDENTIAL
+# Copyright (2002-2014) Intel Corporation All Rights Reserved.
+# The source code contained or described herein and all documents related to
+# the source code ("Material") are owned by Intel Corporation or its suppliers
+# or licensors. Title to the Material remains with Intel Corporation or its
+# suppliers and licensors. The Material contains trade secrets and proprietary
+# and confidential information of Intel or its suppliers and licensors. The
+# Material is protected by worldwide copyright and trade secret laws and
+# treaty provisions. No part of the Material may be used, copied, reproduced,
+# modified, published, uploaded, posted, transmitted, distributed, or
+# disclosed in any way without Intel's prior express written permission.
+#
+# No license under any patent, copyright, trade secret or other intellectual
+# property right is granted to or conferred upon you by disclosure or
+# delivery of the Materials, either expressly, by implication, inducement,
+# estoppel or otherwise. Any license under such intellectual property rights
+# must be express and approved by Intel in writing.
+#
+#----------------------------------------------------------------------------
+
+LOCAL_PATH:= $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_CPPFLAGS += \
+        -DANDROID \
+        -DANDROID_VERSION=800 \
+	-DHDCP_LOG_TAG="\"HDCP_SDK\"" \
+
+ifeq ($(ENABLE_DEBUG),1)
+    LOCAL_CPPFLAG += \
+        -DLOG_CONSOLE \
+        -DHDCP_USE_VERBOSE_LOGGING \
+        -DHDCP_USE_FUNCTION_LOGGING \
+        -DHDCP_USE_LINK_FUNCTION_LOGGING
+endif
+
+#WA
+LOCAL_CPPFLAGS += \
+    -Wno-error
+
+LOCAL_C_INCLUDES += \
+    $(LOCAL_PATH)/../sdk \
+    $(LOCAL_PATH)/../daemon \
+    $(LOCAL_PATH)/../common \
+
+LOCAL_SRC_FILES := \
+    hdcpapi.cpp \
+    sessionmanager.cpp \
+    session.cpp \
+
+LOCAL_SHARED_LIBRARIES := \
+    libutils \
+    liblog \
+
+LOCAL_STATIC_LIBRARIES := \
+    libhdcpcommon \
+
+LOCAL_EXPORT_C_INCLUDE_DIRS = \
+    $(LOCAL_PATH)/
+
+LOCAL_MODULE := libhdcpsdk
+LOCAL_PROPRIETARY_MODULE := true
+
+include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
Add Android Makefile to build hdcp on Android. With this Android.mk
this module can be built either using mm, mma or make from Android root
directory.

To make specific module, the module name is specified in each of the added
Android.mk

Change-Id: Ib1de06c25a5fb8da95f92bef53dbc292042c7ac8
Signed-off-by: khairul.anuar.romli@intel.com