### PR TITLE
main: fix hdcpd service failure

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -36,6 +36,7 @@
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <iostream>
+#include <sys/wait.h>
 
 #include "hdcpdef.h"
 #include "srm.h"
@@ -93,6 +94,8 @@ int32_t daemon_init(void)
     }
     else if (pid != 0)
     {
+        int status;
+        wait(&status);
         exit(SUCCESS);    // parent exit
     }
 


### PR DESCRIPTION
Child process not able to finish before parent process
exits, which causing hdcpd service failure.

Added wait function to block parent process
until child process exits.

Issue is observed if CMAKE_BUILD_TYPE=Release

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>