### PR TITLE
PortManager::GetDownstreamInfo: check data pointer return by drmModeG…

### DIFF
--- a/daemon/portmanager.cpp
+++ b/daemon/portmanager.cpp
@@ -1304,9 +1304,11 @@ int32_t PortManager::GetDownstreamInfo(
     auto blobInfo = drmModeGetPropertyBlob(
                                 m_DrmFd,
                                 blobId);
-    if (nullptr == blobInfo)
+    if (!blobInfo || !blobInfo->data)
     {
         HDCP_ASSERTMESSAGE("Failed to get downstream info blob");
+        if (blobInfo)
+            drmModeFreePropertyBlob(blobInfo);
         drmModeFreeObjectProperties(properties); 
         return EBUSY;
     }


### PR DESCRIPTION
Rebasing for 1A HDCP. Checking For the blobinfo->data and blobinfo. 

Change-Id: I4ea024ce0dc3b6dc5bfd502d3bae715c014c4ba5
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70817
Reviewed-on: https://android.intel.com:443/650125