### PR TITLE
Dispatch pending request to get all the events and indentation fix

### DIFF
--- a/daemon/display_window_util_wl.cpp
+++ b/daemon/display_window_util_wl.cpp
@@ -51,13 +51,13 @@ EGLNativeDisplayType util_create_display(int screen)
 	EGLNativeDisplayType ret = 0;
 	void *init;
 
-        lib_hdl = dlopen(IAS_WL_LIBNAME, RTLD_LAZY | RTLD_GLOBAL);
+	lib_hdl = dlopen(IAS_WL_LIBNAME, RTLD_LAZY | RTLD_GLOBAL);
 	if(!lib_hdl) {
 		cerr<<"Couldn't open lib "<<IAS_WL_LIBNAME<<endl;
 		return 0;
-        }
+	}
 
-        /* Find init symbol */
+	/* Find init symbol */
 	init = dlsym(lib_hdl, "init");
 	if(!init) {
 		cerr<<"Couldn't open symbol init dlerror "<<dlerror()<<endl;
@@ -76,14 +76,14 @@ EGLNativeDisplayType util_create_display(int screen)
 	/* Call class's function */
 	ret = gwl->init();
 	if(ret == 0) {
-               cerr<<"WL base Class init is failed"<<endl;
-               dlclose(lib_hdl);
-               return 0;
-        }
+		cerr<<"WL base Class init is failed"<<endl;
+		dlclose(lib_hdl);
+		return 0;
+	}
 	gwl->add_reg();
 
-        stage = CREATE_DISPLAY_DONE;
-        return ret;
+	stage = CREATE_DISPLAY_DONE;
+	return ret;
 }
 
 void util_destroy_display(EGLNativeDisplayType display)
@@ -112,9 +112,9 @@ void util_destroy_display(EGLNativeDisplayType display)
 bool util_set_content_protection(int crtc, int cp)
 {
 
-        bool retval = false;
+	bool retval = false;
 
-        if(stage != CREATE_DISPLAY_DONE) {
+	if(stage != CREATE_DISPLAY_DONE) {
 		cerr<<"Must call util_create_display first"<<endl;
 		return retval;
 	}
@@ -127,8 +127,8 @@ bool util_set_content_protection(int crtc, int cp)
 	retval = gwl->set_content_protection(crtc, cp);
 	if (retval != true)
 	{
-	    cerr<<"Failed to set content protection and ret value =%0x"<<retval<<endl;
-	    return retval;
+		cerr<<"Failed to set content protection and ret value =%0x"<<retval<<endl;
+		return retval;
 	}
-        return true;
+	return true;
 }

--- a/daemon/display_window_util_wl.cpp
+++ b/daemon/display_window_util_wl.cpp
@@ -81,6 +81,7 @@ EGLNativeDisplayType util_create_display(int screen)
 		return 0;
 	}
 	gwl->add_reg();
+	gwl->dispatch_pending();
 
 	stage = CREATE_DISPLAY_DONE;
 	return ret;


### PR DESCRIPTION
Submitting two patches.
1) Just fixing indentation
2) Adding a patch in util wayland where we are missing getting some events from the compositor. This causes an issue down the road when we expect to have CRTC data but don't.