### PR TITLE
Fix for BKSV values zero

### DIFF
--- a/daemon/portmanager.cpp
+++ b/daemon/portmanager.cpp
@@ -970,7 +970,7 @@ int32_t PortManager::GetKsvList(
     DownstreamInfo dsInfo;
     int32_t ret = GetDownstreamInfo(
                             GetDrmObjectByPortId(portId),
-                            (uint8_t *)&dsInfo);
+                            (uint8_t *)&dsInfo.bksv[0]);
     if (SUCCESS != ret)
     {
         HDCP_ASSERTMESSAGE("Faild to get down stream info");


### PR DESCRIPTION
cp_downstream_info structure, which is from the kernel(drm_mode.h) having following member,
struct cp_downstream_info {
	char bksv[DRM_MODE_HDCP_KSV_LEN];
	bool is_repeater;
	__u8 depth;
	__u32 device_count;
	char ksv_list[DRM_MODE_HDCP_KSV_LEN * DRM_MODE_HDCP_MAX_DEVICE_CNT];
};

whereas in the HDCP-daemon, we   have 2 more additional members at the beginning of structure such as version and cp_type, passing this structure reference to the memmove will cause incompatible data alignment among the members. So passing the reference of the structure with  the index of  bksv[0] will solve the bksv values getting displayed as ZERO .

Change-Id: Ia3d88dcbfc8e686eca14994e118d038585a16b5f